### PR TITLE
Secured routes

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/ControllerSpi.java
+++ b/src/main/java/org/reaktivity/nukleus/ControllerSpi.java
@@ -31,7 +31,13 @@ public interface ControllerSpi
 
     void doClose();
 
-    <R> CompletableFuture<R> doCommand(
+    CompletableFuture<Long> doResolve(
+        int msgTypeId,
+        DirectBuffer buffer,
+        int index,
+        int length);
+
+    CompletableFuture<Void> doUnresolve(
         int msgTypeId,
         DirectBuffer buffer,
         int index,

--- a/src/main/java/org/reaktivity/nukleus/ControllerSpi.java
+++ b/src/main/java/org/reaktivity/nukleus/ControllerSpi.java
@@ -31,6 +31,12 @@ public interface ControllerSpi
 
     void doClose();
 
+    <R> CompletableFuture<R> doCommand(
+        int msgTypeId,
+        DirectBuffer buffer,
+        int index,
+        int length);
+
     CompletableFuture<Long> doRoute(
         int msgTypeId,
         DirectBuffer buffer,

--- a/src/main/java/org/reaktivity/nukleus/NukleusBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/NukleusBuilder.java
@@ -15,6 +15,9 @@
  */
 package org.reaktivity.nukleus;
 
+import java.util.function.Consumer;
+
+import org.agrona.concurrent.MessageHandler;
 import org.reaktivity.nukleus.function.MessagePredicate;
 import org.reaktivity.nukleus.route.RouteKind;
 import org.reaktivity.nukleus.stream.StreamFactoryBuilder;
@@ -31,6 +34,15 @@ public interface NukleusBuilder
 
     NukleusBuilder inject(
         Nukleus component);
+
+    NukleusBuilder resolveHandler(
+    MessageHandler handler);
+
+    NukleusBuilder unresolveHandler(
+    MessageHandler handler);
+
+    NukleusBuilder getCommandReply(
+    Consumer<MessageHandler> reply);
 
     Nukleus build();
 }

--- a/src/main/java/org/reaktivity/nukleus/NukleusBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/NukleusBuilder.java
@@ -17,7 +17,7 @@ package org.reaktivity.nukleus;
 
 import java.util.function.Consumer;
 
-import org.agrona.concurrent.MessageHandler;
+import org.reaktivity.nukleus.function.MessageConsumer;
 import org.reaktivity.nukleus.function.MessagePredicate;
 import org.reaktivity.nukleus.route.RouteKind;
 import org.reaktivity.nukleus.stream.StreamFactoryBuilder;
@@ -36,13 +36,13 @@ public interface NukleusBuilder
         Nukleus component);
 
     NukleusBuilder resolveHandler(
-    MessageHandler handler);
+    MessageConsumer handler);
 
     NukleusBuilder unresolveHandler(
-    MessageHandler handler);
+    MessageConsumer handler);
 
     NukleusBuilder getCommandReply(
-    Consumer<MessageHandler> reply);
+    Consumer<MessageConsumer> reply);
 
     Nukleus build();
 }

--- a/src/main/java/org/reaktivity/nukleus/function/CommandHandler.java
+++ b/src/main/java/org/reaktivity/nukleus/function/CommandHandler.java
@@ -16,9 +16,10 @@
 package org.reaktivity.nukleus.function;
 
 import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
 
 @FunctionalInterface
 public interface CommandHandler
 {
-    void handle(DirectBuffer buffer, int index, int length, MessageConsumer replyTo);
+    void handle(DirectBuffer buffer, int index, int length, MessageConsumer replyTo, MutableDirectBuffer replyBuffer);
 }

--- a/src/main/java/org/reaktivity/nukleus/function/CommandHandler.java
+++ b/src/main/java/org/reaktivity/nukleus/function/CommandHandler.java
@@ -13,29 +13,12 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package org.reaktivity.nukleus;
+package org.reaktivity.nukleus.function;
 
-import org.reaktivity.nukleus.function.CommandHandler;
-import org.reaktivity.nukleus.function.MessagePredicate;
-import org.reaktivity.nukleus.route.RouteKind;
-import org.reaktivity.nukleus.stream.StreamFactoryBuilder;
+import org.agrona.DirectBuffer;
 
-public interface NukleusBuilder
+@FunctionalInterface
+public interface CommandHandler
 {
-    NukleusBuilder routeHandler(
-        RouteKind kind,
-        MessagePredicate handler);
-
-    NukleusBuilder streamFactory(
-        RouteKind kind,
-        StreamFactoryBuilder builder);
-
-    NukleusBuilder inject(
-        Nukleus component);
-
-    NukleusBuilder commandHandler(
-        int msgTypeId,
-        CommandHandler handler);
-
-    Nukleus build();
+    void handle(DirectBuffer buffer, int index, int length, MessageConsumer replyTo);
 }

--- a/src/main/java/org/reaktivity/nukleus/route/RouteManager.java
+++ b/src/main/java/org/reaktivity/nukleus/route/RouteManager.java
@@ -22,6 +22,7 @@ import org.reaktivity.nukleus.function.MessagePredicate;
 public interface RouteManager
 {
     <R> R resolve(
+        long authorization,
         MessagePredicate filter,
         MessageFunction<R> mapper);
 

--- a/src/main/java/org/reaktivity/nukleus/stream/StreamFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/stream/StreamFactoryBuilder.java
@@ -16,9 +16,9 @@
 package org.reaktivity.nukleus.stream;
 
 import java.util.function.Function;
-import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
+import java.util.function.ToLongFunction;
 
 import org.agrona.MutableDirectBuffer;
 import org.reaktivity.nukleus.buffer.BufferPool;
@@ -48,7 +48,7 @@ public interface StreamFactoryBuilder
     }
 
     default StreamFactoryBuilder setRealmIdSupplier(
-        LongFunction<String> supplyScope)
+        ToLongFunction<String> supplyRealmId)
     {
         return this;
     }

--- a/src/main/java/org/reaktivity/nukleus/stream/StreamFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/stream/StreamFactoryBuilder.java
@@ -16,6 +16,7 @@
 package org.reaktivity.nukleus.stream;
 
 import java.util.function.Function;
+import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
@@ -42,6 +43,12 @@ public interface StreamFactoryBuilder
 
     default StreamFactoryBuilder setCounterSupplier(
         Function<String, LongSupplier> supplyCounter)
+    {
+        return this;
+    }
+
+    default StreamFactoryBuilder setRealmIdSupplier(
+        LongFunction<String> supplyScope)
     {
         return this;
     }

--- a/src/main/java/org/reaktivity/nukleus/stream/StreamFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/stream/StreamFactoryBuilder.java
@@ -18,7 +18,6 @@ package org.reaktivity.nukleus.stream;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
-import java.util.function.ToLongFunction;
 
 import org.agrona.MutableDirectBuffer;
 import org.reaktivity.nukleus.buffer.BufferPool;
@@ -43,12 +42,6 @@ public interface StreamFactoryBuilder
 
     default StreamFactoryBuilder setCounterSupplier(
         Function<String, LongSupplier> supplyCounter)
-    {
-        return this;
-    }
-
-    default StreamFactoryBuilder setRealmIdSupplier(
-        ToLongFunction<String> supplyRealmId)
     {
         return this;
     }

--- a/src/test/java/org/reaktivity/nukleus/NukleusFactoryTest.java
+++ b/src/test/java/org/reaktivity/nukleus/NukleusFactoryTest.java
@@ -21,8 +21,8 @@ import static org.junit.Assert.assertThat;
 import java.io.IOException;
 import java.util.function.Consumer;
 
-import org.agrona.concurrent.MessageHandler;
 import org.junit.Test;
+import org.reaktivity.nukleus.function.MessageConsumer;
 import org.reaktivity.nukleus.function.MessagePredicate;
 import org.reaktivity.nukleus.route.RouteKind;
 import org.reaktivity.nukleus.stream.StreamFactoryBuilder;
@@ -68,21 +68,21 @@ public final class NukleusFactoryTest
 
             @Override
             public NukleusBuilder resolveHandler(
-                MessageHandler handler)
+                MessageConsumer handler)
             {
                 return this;
             }
 
             @Override
             public NukleusBuilder unresolveHandler(
-                MessageHandler handler)
+                MessageConsumer handler)
             {
                 return this;
             }
 
             @Override
             public NukleusBuilder getCommandReply(
-                Consumer<MessageHandler> reply)
+                Consumer<MessageConsumer> reply)
             {
                 return this;
             }

--- a/src/test/java/org/reaktivity/nukleus/NukleusFactoryTest.java
+++ b/src/test/java/org/reaktivity/nukleus/NukleusFactoryTest.java
@@ -19,7 +19,9 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
+import org.agrona.concurrent.MessageHandler;
 import org.junit.Test;
 import org.reaktivity.nukleus.function.MessagePredicate;
 import org.reaktivity.nukleus.route.RouteKind;
@@ -62,6 +64,27 @@ public final class NukleusFactoryTest
             public Nukleus build()
             {
                 return null;
+            }
+
+            @Override
+            public NukleusBuilder resolveHandler(
+                MessageHandler handler)
+            {
+                return this;
+            }
+
+            @Override
+            public NukleusBuilder unresolveHandler(
+                MessageHandler handler)
+            {
+                return this;
+            }
+
+            @Override
+            public NukleusBuilder getCommandReply(
+                Consumer<MessageHandler> reply)
+            {
+                return this;
             }
         };
 

--- a/src/test/java/org/reaktivity/nukleus/NukleusFactoryTest.java
+++ b/src/test/java/org/reaktivity/nukleus/NukleusFactoryTest.java
@@ -19,10 +19,9 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
-import java.util.function.Consumer;
 
 import org.junit.Test;
-import org.reaktivity.nukleus.function.MessageConsumer;
+import org.reaktivity.nukleus.function.CommandHandler;
 import org.reaktivity.nukleus.function.MessagePredicate;
 import org.reaktivity.nukleus.route.RouteKind;
 import org.reaktivity.nukleus.stream.StreamFactoryBuilder;
@@ -67,22 +66,9 @@ public final class NukleusFactoryTest
             }
 
             @Override
-            public NukleusBuilder resolveHandler(
-                MessageConsumer handler)
-            {
-                return this;
-            }
-
-            @Override
-            public NukleusBuilder unresolveHandler(
-                MessageConsumer handler)
-            {
-                return this;
-            }
-
-            @Override
-            public NukleusBuilder getCommandReply(
-                Consumer<MessageConsumer> reply)
+            public NukleusBuilder commandHandler(
+                int msgTypeId,
+                CommandHandler handler)
             {
                 return this;
             }


### PR DESCRIPTION
API changes for secured routes:
- (**incompatible API change**) Added authorization parameter to RouteManager.resolve method
- Added ability to add a command handler to NukleusBuilder (to allow security nuklei to implement resolve and unresolve)
- Added methods to ControllerSpi to allow controllers to implement resolve and unresolve